### PR TITLE
ADR to use light python wrapper

### DIFF
--- a/documentation/adr/0010-use-compiled-matlab-for-python.md
+++ b/documentation/adr/0010-use-compiled-matlab-for-python.md
@@ -1,4 +1,4 @@
-[<-previous](0009-brille-integration.md) | [next->](0011-use-mex-for-pyHorace-python-calls)
+[<-previous](0009-brille-integration.md) | [next->](0011-use-mex-for-pyHorace-python-calls.md)
 
 # 10. Use Compiled Matlab library for Python users to run PACE
 

--- a/documentation/adr/0011-use-mex-for-pyHorace-python-calls.md
+++ b/documentation/adr/0011-use-mex-for-pyHorace-python-calls.md
@@ -1,6 +1,6 @@
-[<-previous](0009-brille-integration.md) | next->
+[<-previous](0010-use-compiled-matlab-for-python.md) | [next->](0012-matlab-python-wrapper.md)
 
-# 10. pyHorace Matlab code should use a mex interface to call Python functions
+# 11. pyHorace Matlab code should use a mex interface to call Python functions
 
 Date: 2020-Dec-02
 

--- a/documentation/adr/0012-matlab-python-wrapper.md
+++ b/documentation/adr/0012-matlab-python-wrapper.md
@@ -1,4 +1,4 @@
-[<-previous](0011-use-mex-for-pyHorace-python-calls.md) | [next->]()
+[<-previous](0011-use-mex-for-pyHorace-python-calls.md) | [next->](0013-light-python-wrapper-implementation-detail.md)
 
 # 12. A Matlab wrapper for Python PACE projects
 
@@ -6,18 +6,18 @@ Date: 2021-Jan-01
 
 ## Status
 
-Proposed
+Accepted
 
 
 ## Context
 
-Both Euphonic and Brille are PACE projects with primarily a Python interface.
-PACE, however, aims to provide both a Python and a Matlab interface to users,
+Both Euphonic and Brille are PACE projects with primarily a Python user interface (UI).
+PACE, however, aims to provide both a Python and a Matlab UI to users,
 and also to foster inter-operability between projects which are written both in Matlab and Python.
 In particular, `pyHorace` ([prototype](https://github.com/mducle/hugo)) cannot use the 
 [standard method](https://uk.mathworks.com/help/matlab/call-python-libraries.html) for Matlab to run Python code, 
 where calls to Python from Matlab are prefixed with `py.` followed by the full module specification.
-For example, `r = py.numpy.random.rand(3)` uses `numpy` to generate a random number.
+For example, `r = py.numpy.random.rand()` uses `numpy` to generate a random number.
 This is because such a call causes Matlab to 
 [automatically spawn](https://uk.mathworks.com/help/matlab/ref/pyenv.html) a dependent Python interpreter,
 which can be either created within the same process as the Matlab interpreter (`InProcess`)
@@ -32,34 +32,32 @@ but this imposes a significant performance penalty
 
 ## Proposal
 
-So, we propose that the Matlab interface to Euphonic and Brille would be through a Python wrapper class.
+So, we propose that the Matlab UI to Euphonic and Brille would be through a Python wrapper class.
 There would be two implementation of this class.
-One (used by Matlab users) would call to `py.*` internally, whilst the other
-(used by `pyHorace`) would use the mechanism described in the [python interface design](../../python_interface/design).
-Most importantly, no Matlab code which would be compiled would have reference to `py.*`
-which would cause a crash in `pyHorace`.
+One (used by the Matlab UI) would have calls to `py.*` internally, whilst the other
+(used by the Python UI) would use the mechanism described in the [python interface design](../../python_interface/design).
+Most importantly, no Matlab code which would be compiled would have references to `py.*`
+which would otherwise cause a crash in `pyHorace`.
 
 An important benefit of this Python wrapper class is that mimimal Matlab code would be needed
 to expose Euphonic or Brille (or indeed any other Python program) to Matlab.
-The [proposed wrapper](https://github.com/mducle/horace-euphonic-interface/blob/light_wrapper/%2Beuphonic/light_python_wrapper.m)
+The [proposed wrapper](https://github.com/pace-neutrons/light_python_wrapper)
 also handles data conversion and translation between Python and Matlab keyword arguments and some error checking.
 Finally, the wrapper also exposes the `pydoc` documentation system
 allowing users in Matlab to access the Python documentation transparently,
 and to use tab-completion to access the properties and methods of the Python class or object.
 
-To make it flexible (to allow for example the Euphonic Matlab interface to be more easily distributed on the File-Exchange),
-we propose to make this Python wrapper class a separate github repository which is either included as a submodule
-or purely in the build system (e.g. a cmake external project).
-
 
 ## Decision
 
-A decision will be taken at a forthcoming meeting.
+At a meeting on Jan 7 2021, the developers of `pyHorace`, `brillem` and `horace-euphonic-interface` agreed to accept this proposal.
+`brillem` and `horace-euphonic-interface` will be refactored to use the `light_python_wrapper` proposed here.
+The meeting also agreed implementation details which will be described in [ADR #13](0013-light-python-wrapper-implementation-detail.md).
 
 
 ## Consequences
 
 The current [`horace-euphonic-interface`](https://github.com/pace-neutrons/horace-euphonic-interface/) and
-[`brillem`](https://github.com/brille/brillem/) code would need to be refactored to use the wrapper,
-with open pull requests [for Euphonic](https://github.com/pace-neutrons/horace-euphonic-interface/pull/3)
-and [brillem](https://github.com/brille/brillem/pull/4).
+[`brillem`](https://github.com/brille/brillem/) code would need to be refactored to use the wrapper.
+Pull requests [for Euphonic](https://github.com/pace-neutrons/horace-euphonic-interface/pull/4)
+and [brillem](https://github.com/brille/brillem/pull/4) will implement this refactoring.

--- a/documentation/adr/0012-matlab-python-wrapper.md
+++ b/documentation/adr/0012-matlab-python-wrapper.md
@@ -14,13 +14,25 @@ Proposed
 Both Euphonic and Brille are PACE projects with primarily a Python interface.
 PACE, however, aims to provide both a Python and a Matlab interface to users,
 and also to foster inter-operability between projects which are written both in Matlab and Python.
-In particular, `pyHorace` ([prototype](https://github.com/mducle/hugo)), cannot use the standard
-method for Matlab to run Python code, using the `py.*` namespace.
+In particular, `pyHorace` ([prototype](https://github.com/mducle/hugo)) cannot use the 
+[standard method](https://uk.mathworks.com/help/matlab/call-python-libraries.html) for Matlab to run Python code, 
+where calls to Python from Matlab are prefixed with `py.` followed by the full module specification.
+For example, `r = py.numpy.random.rand(3)` uses `numpy` to generate a random number.
+This is because such a call causes Matlab to 
+[automatically spawn](https://uk.mathworks.com/help/matlab/ref/pyenv.html) a dependent Python interpreter,
+which can be either created within the same process as the Matlab interpreter (`InProcess`)
+or in an external process (`OutOfProcess`).
+`pyHorace` already runs within a Python interpreter and the compiled Matlab library *must* be loaded in-process.
+Thus, if Matlab spawns a second Python intepreter with the default `InProcess` execution mode,
+the two Python interpreters will conflict causing memory errors and a crash.
+We can force Matlab to launch the dependent Python interpreter `OutOfProcess`
+but this imposes a significant performance penalty
+(extensive testing was not done but Brille+SpinW runs about 10x slower than with `InProcess`). 
 
 
 ## Proposal
 
-Thus it is proposed that the Matlab interface to Euphonic and Brille would be through a Python wrapper class.
+So, we propose that the Matlab interface to Euphonic and Brille would be through a Python wrapper class.
 There would be two implementation of this class.
 One (used by Matlab users) would call to `py.*` internally, whilst the other
 (used by `pyHorace`) would use the mechanism described in the [python interface design](../../python_interface/design).

--- a/documentation/adr/0012-matlab-python-wrapper.md
+++ b/documentation/adr/0012-matlab-python-wrapper.md
@@ -1,0 +1,53 @@
+[<-previous](0011-use-mex-for-pyHorace-python-calls.md) | [next->]()
+
+# 12. A Matlab wrapper for Python PACE projects
+
+Date: 2021-Jan-01
+
+## Status
+
+Proposed
+
+
+## Context
+
+Both Euphonic and Brille are PACE projects with primarily a Python interface.
+PACE, however, aims to provide both a Python and a Matlab interface to users,
+and also to foster inter-operability between projects which are written both in Matlab and Python.
+In particular, `pyHorace` ([prototype](https://github.com/mducle/hugo)), cannot use the standard
+method for Matlab to run Python code, using the `py.*` namespace.
+
+
+## Proposal
+
+Thus it is proposed that the Matlab interface to Euphonic and Brille would be through a Python wrapper class.
+There would be two implementation of this class.
+One (used by Matlab users) would call to `py.*` internally, whilst the other
+(used by `pyHorace`) would use the mechanism described in the [python interface design](../../python_interface/design).
+Most importantly, no Matlab code which would be compiled would have reference to `py.*`
+which would cause a crash in `pyHorace`.
+
+An important benefit of this Python wrapper class is that mimimal Matlab code would be needed
+to expose Euphonic or Brille (or indeed any other Python program) to Matlab.
+The [proposed wrapper](https://github.com/mducle/horace-euphonic-interface/blob/light_wrapper/%2Beuphonic/light_python_wrapper.m)
+also handles data conversion and translation between Python and Matlab keyword arguments and some error checking.
+Finally, the wrapper also exposes the `pydoc` documentation system
+allowing users in Matlab to access the Python documentation transparently,
+and to use tab-completion to access the properties and methods of the Python class or object.
+
+To make it flexible (to allow for example the Euphonic Matlab interface to be more easily distributed on the File-Exchange),
+we propose to make this Python wrapper class a separate github repository which is either included as a submodule
+or purely in the build system (e.g. a cmake external project).
+
+
+## Decision
+
+A decision will be taken at a forthcoming meeting.
+
+
+## Consequences
+
+The current [`horace-euphonic-interface`](https://github.com/pace-neutrons/horace-euphonic-interface/) and
+[`brillem`](https://github.com/brille/brillem/) code would need to be refactored to use the wrapper,
+with open pull requests [for Euphonic](https://github.com/pace-neutrons/horace-euphonic-interface/pull/3)
+and [brillem](https://github.com/brille/brillem/pull/4).


### PR DESCRIPTION
Adds an architectural design record to propose to use a wrapper around Python code for use in Matlab for the Matlab interfaces for Brille and Euphonic.