### PR TITLE
Update Euphonic release instructions

### DIFF
--- a/euphonic/development/02_releases.md
+++ b/euphonic/development/02_releases.md
@@ -3,52 +3,33 @@
 Euphonic follows [semantic versioning](https://semver.org/) and releases on
 Github, PyPI and Conda (via the conda-forge channel).
 
-There is a script in the main Euphonic repo,`release.py` for releasing on Github,
-new releases should automatically trigger a workflow to release on PyPI, which
-will trigger a new PR for the Conda release in
-https://github.com/conda-forge/euphonic-feedstock.
+The release process for Euphonic has been changed at the beginning of
+2025 to be more streamlined and facilitate pre-releases or bugfixes on
+historical releases. Most steps are performed by Github Actions
+workflows; some of these use scripts located in the *build_utils/*.
 
-Currently releases are done from `master` rather than having a release branch.
-This may change in the future as the project evolves.
+The only thing that really cannot be fixed are the packages uploaded
+to PyPI. If we upload a bad release to PyPI, the only solution is to
+mark it as "yanked", increment the version number and release a new
+version. The release workflow includes a lot of tests and
+sanity-checks to reduce the likelihood of this scenario.
 
-# Release process
-## 1. Ensure tests pass on all Python versions
-By default Euphonic tests only run on the lowest and highest supported Python
-versions (e.g. 3.7 and 3.10) for each commit. Before a release, all
-intermediate versions should also be tested (e.g. 3.8, 3.9). To run tests on
-the intermediate versions, a
-[workflow dispatch](https://docs.github.com/en/actions/using-workflows/events-that-trigger-workflows#workflow_dispatch)
-can be used to manually run the tests on the master branch, this will run for
-all supported Python verisons. Make sure these all pass before moving on to
-the next step.
+# Release process:
+## 0. Consider tidying up metadata (CHANGELOG.rst, CITATION.cff)
 
-## 2. Update the changelog
-* Update the `Unreleased` title in `CHANGELOG.rst` and the associated Github
-compare to the new version e.g.
-```
-`Unreleased <https://github.com/pace-neutrons/Euphonic/compare/v0.2.2...HEAD>`_
-----------
-```
-becomes:
-```
-`v0.2.3 <https://github.com/pace-neutrons/Euphonic/compare/v0.2.2...v0.2.3>`_
-------
-```
+If good practice has been followed, CHANGELOG.rst should already have
+a presentable-looking "Unreleased" section; this will automatically be
+used as notes for the new version.
 
-* Add a new `Unreleased` line e.g.
-```
-`Unreleased <https://github.com/pace-neutrons/Euphonic/compare/v0.2.3...HEAD>`_
-----------
-```
-Note the compare in `Unreleased` now compares with the latest version v0.2.3
-not v0.2.2
+> **NOTE:** pre-releases do not get a CHANGELOG update, as the new
+> features are still officially "Unreleased".
 
-## 3. Update CITATION.cff
+Similarly, CITATION.cff _should_ have been updated with new
+contributors when a significant contribution was made to the project.
 
-The 'version' and 'date-released' fields should be updated to the new version
-and current date
+There is no need to change the version number yet.
 
-## 4. Update any new deprecated directives
+## 1. Update any new deprecated directives
 
 Euphonic uses Numpy docstrings, which recommends use of Sphinx deprecated directives
 https://numpydoc.readthedocs.io/en/latest/format.html#sections. When these are added,
@@ -58,66 +39,56 @@ accurate. e.g. if you are releasing v0.5.2, and you see a deprecated directive t
 shows version v0.6.0, it should be corrected to v0.5.2 as that is the correct next
 release after the deprecation
 
-## 5. Commit and tag changes (don't push yet)
-Commit the changes made to `CHANGELOG.rst` and tag the commit with the new
-version e.g.:
+## 2. Create a release branch and wait for tests to pass.
 
-```
-git tag v0.2.3
-```
-Versioning is managed by
-[versioneer](https://github.com/warner/python-versioneer) so once a
-commit has been tagged, this will update `euphonic.__version__`
-automatically
+Create a branch with "release" somewhere in the name and push to
+GitHub. This will trigger a "run-tests" workflow which can be
+monitored here[https://github.com/pace-neutrons/Euphonic/actions].
 
-## 6. Test Github release.py
-Running `release.py` with the `--github` flag will generate a JSON payload that
-can be posted to Github's release API (see the script for details on how it
-generates this). By default it will just print the payload, this is useful to
-check the payload is being generated correctly. Make sure to check the 
-version/body etc. are all what you expect. If it's not what you expect, now
-is the time to make any changes, as the commit/tag haven't been pushed yet,
-the tag can still be deleted and reapplied once any fixes have been made.
+> **NOTE:** unlike the automatic PR tests, this will include all
+> supported platforms and python versions.
+> A full test can also be run on a PR by using a manual dispatch
+> of run-tests, targeting the appropriate branch.
 
-## 7. Push the commit
-If you're happy with the Github test release, push the commit/tag to master.
+## 3. Run the Release workflow
 
-## 8. Actually release on Github
-To actually post to Github run
-`python release.py --github --notest`
+In the [Github Actions](https://github.com/pace-neutrons/Euphonic/actions)
+sidebar choose "Create a release" (release.yml) workflow and run
+specifying the release branch and proposed version number.
 
-This will create a release. To authenticate, it uses a Github 
-[personal access token](https://help.github.com/en/github/authenticating-to-github/creating-a-personal-access-token-for-the-command-line).
-Set it as the `GITHUB_TOKEN` envronment variable and it will be used to
-authenticate.
+- Pre-releases should have text after the semver number, such as "v1.4.1rc2".
+- It should generally be safe to enable "Make release and push to PyPI" without a dry-run: the workflow will exit early if a step fails.
 
-This should start a Github actions workflow `build_upload_pypi_wheels.yml`
-which will build and upload a source and various wheels to PyPI. It
-should also start a workflow `create-landing-page.yml` which should
-publish a new version page to the `gh-pages` branch
+### Fixing a failed release workflow
 
-## 9. Test PyPI releases
-There is a `test_release.yml` workflow that must be triggered manually with
-a workflow dispatch. Run the workflow with the release version to check all
-the PyPI builds succeed. The Conda builds may fail if a Conda release hasn't
-been made yet
+- Small problems can be fixed on the release branch. Consider making a pull-request to master so these can be reviewed more easily; the branch can still be used to release.
+- If something went wrong after the "Bump version number" step, you will need to delete the new git tag from https://github.com/pace-neutrons/Euphonic/tags
+- If something went wrong after making a Github release, you will need to delete the release from https://github.com/pace-neutrons/Euphonic/releases
+- If good packages were already uploaded to PyPI but something went wrong producing the landing page, you don't need to redo the release. Fix it directly on the gh-pages branch.
+- When things are looking good, run the release workflow again.
 
-## 10. Test versioned landing page
-The above mentioned  `create-landing-page.yml` workflow should have created
-a versioned page e.g. https://pace-neutrons.github.io/Euphonic/versions/v0.6.2.html,
-check it looks sensible
+## 4. Check versioned landing page
+The release workflow should have called `create-landing-page.yml` to create
+a versioned page e.g. https://pace-neutrons.github.io/Euphonic/versions/v0.6.2.html;
+check it looks sensible.
 
-## 11. Update conda-forge package
-Wait for the conda-forge bot to open a PR in https://github.com/conda-forge/euphonic-feedstock,
-this may take a few hours. Make sure all the tests pass, and merge the PR.
+## 5. Post-release testing: PyPI
+There is a "Test PyPI release" (_test_release_release.yml_) workflow
+that must be triggered manually with a workflow dispatch. Run the
+workflow with the release version to check installation from PyPI
+works and tests pass.
 
-## 12. Test conda-forge package
+## 6. Update conda-forge package After the release hits PyPI, wait
+for the conda-forge bot to open a PR in
+https://github.com/conda-forge/euphonic-feedstock : this may take a few
+hours. Make sure all the tests pass, and merge the PR.
+
+## 7. Test conda-forge package
 Once the PR has been merged and the triggered jobs have completed, Euphonic
-should be available on the conda-forge channel. Run the `test_release.yml`
-workflow in the Euphonic repo to check that the PyPI and conda packages
+should be available on the conda-forge channel. Run the "Test Conda-forge release" (_test_release.yml_) workflow in the Euphonic repo to check that the PyPI and conda packages
 pass tests
 
-## 13. Request DOI
+## 8. Request DOI
 A DOI will need to be requested for the new version, this can be obtained from
 the Software Engineering Group in the Scientific Computing Department (contact
 for this as of 10/11/22 is Antony Wilson). Alternatively, access can be

--- a/euphonic/development/02_releases.md
+++ b/euphonic/development/02_releases.md
@@ -43,7 +43,7 @@ release after the deprecation
 
 Create a branch with "release" somewhere in the name and push to
 GitHub. This will trigger a "run-tests" workflow which can be
-monitored here[https://github.com/pace-neutrons/Euphonic/actions].
+monitored [here](https://github.com/pace-neutrons/Euphonic/actions).
 
 > **NOTE:** unlike the automatic PR tests, this will include all
 > supported platforms and python versions.
@@ -53,15 +53,15 @@ monitored here[https://github.com/pace-neutrons/Euphonic/actions].
 ## 3. Run the Release workflow
 
 In the [Github Actions](https://github.com/pace-neutrons/Euphonic/actions)
-sidebar choose "Create a release" (release.yml) workflow and run
+sidebar choose "Create a release" (`release.yml`) workflow and run
 specifying the release branch and proposed version number.
 
-- Pre-releases should have text after the semver number, such as "v1.4.1rc2".
+- Pre-releases should have text after the [semver number](https://packaging.python.org/en/latest/discussions/versioning/), such as "v1.4.1rc2".
 - It should generally be safe to enable "Make release and push to PyPI" without a dry-run: the workflow will exit early if a step fails.
 
 ### Fixing a failed release workflow
 
-- Small problems can be fixed on the release branch. Consider making a pull-request to master so these can be reviewed more easily; the branch can still be used to release.
+- Small problems can be fixed on the release branch. Consider making a pull-request to `master` so these can be reviewed more easily; the branch can still be used to release.
 - If something went wrong after the "Bump version number" step, you will need to delete the new git tag from https://github.com/pace-neutrons/Euphonic/tags
 - If something went wrong after making a Github release, you will need to delete the release from https://github.com/pace-neutrons/Euphonic/releases
 - If good packages were already uploaded to PyPI but something went wrong producing the landing page, you don't need to redo the release. Fix it directly on the gh-pages branch.
@@ -73,19 +73,21 @@ a versioned page e.g. https://pace-neutrons.github.io/Euphonic/versions/v0.6.2.h
 check it looks sensible.
 
 ## 5. Post-release testing: PyPI
-There is a "Test PyPI release" (_test_release_release.yml_) workflow
+There is a "Test PyPI release" (`test_release_release.yml`) workflow
 that must be triggered manually with a workflow dispatch. Run the
 workflow with the release version to check installation from PyPI
 works and tests pass.
 
-## 6. Update conda-forge package After the release hits PyPI, wait
+## 6. Update conda-forge package 
+After the release hits PyPI, wait
 for the conda-forge bot to open a PR in
 https://github.com/conda-forge/euphonic-feedstock : this may take a few
 hours. Make sure all the tests pass, and merge the PR.
 
 ## 7. Test conda-forge package
 Once the PR has been merged and the triggered jobs have completed, Euphonic
-should be available on the conda-forge channel. Run the "Test Conda-forge release" (_test_release.yml_) workflow in the Euphonic repo to check that the PyPI and conda packages
+should be available on the conda-forge channel. Run the "Test Conda-forge release"
+ (`test_release.yml`) workflow in the Euphonic repo to check that the PyPI and conda packages
 pass tests
 
 ## 8. Request DOI


### PR DESCRIPTION
The new process is a lot more automated, but it shouldn't be too painful to recover from minor problems.

The DOI stuff could use a refresh, I didn't have much luck last time I tried to get hold of the relevant people so we are lagging a bit on this. But that doesn't have to be part of this PR.